### PR TITLE
Change returned object to differentiate between public and private me…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.0
+
+Extended returned object to include `publicMethods` and `privateMethods`,
+based on presence of an underscore at the beginning or end of method name.
+
 ### 1.0.0
 
 Patched dev dependencies. Major bump only to being using semver.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/midknight41/examine-instance.svg)](https://greenkeeper.io/)
 
-[![Build Status](https://travis-ci.org/midknight41/examine-instance.svg?branch=master)](https://travis-ci.org/midknight41/examine-instance) 
+[![Build Status](https://travis-ci.org/midknight41/examine-instance.svg?branch=master)](https://travis-ci.org/midknight41/examine-instance)
 
 **examine-instance** inspects an object and its prototype and catalogues the properties and methods.
+Categorises methods as private if they are prefixed or suffixed by an underscore, otherwise marks as public.
 
 ## Installation
 
@@ -33,14 +34,20 @@ class MyClass {
   method1(value) {
     return value;
   }
+
+  method2_(value) {
+    return value;
+  }
 }
 
 const instance = new MyClass();
 const result = examine(instance);
 
 /*
-{ 
-  methods: [ 'method1' ],
+{
+  methods: [ 'method1', 'method2_' ],
+  privateMethods: [ 'method2_' ],
+  publicMethods: [ 'method1' ],
   attributes: [ '_property1', '_isGood' ],
   readOnly: [ 'isGood' ],
   readWrite: [ 'property1' ],

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,6 +2,8 @@ export default function examine(target) {
 
   const examination = {
     methods: [],
+    privateMethods: [],
+    publicMethods: [],
     attributes: [],
     readOnly: [],
     readWrite: [],
@@ -11,6 +13,8 @@ export default function examine(target) {
   const propNames = Object.getOwnPropertyNames(target);
   const proto = Object.getPrototypeOf(target);
   const protoPropNames = Object.getOwnPropertyNames(proto);
+
+  const privateNameExp = /^_|_$/;
 
   // examine the instance
   for (const value of propNames) {
@@ -26,6 +30,14 @@ export default function examine(target) {
     if (descriptor.value !== undefined && typeof descriptor.value === "function") {
 
       examination.methods.push(value);
+
+      const isPrivateMethod = privateNameExp.exec(value);
+
+      if (isPrivateMethod) {
+        examination.privateMethods.push(value);
+      } else {
+        examination.publicMethods.push(value);
+      }
       continue;
     }
 

--- a/src/test/index-test.js
+++ b/src/test/index-test.js
@@ -66,6 +66,10 @@ class MyClass {
   method1(value) {
     return value;
   }
+
+  method2_(value) {
+    return value;
+  }
 }
 
 group("The examine() function", () => {
@@ -74,15 +78,49 @@ group("The examine() function", () => {
 
     const obj = {
       method1: () => { return; },
-      method2: () => { return; },
-      method3: () => { return; }
+      method2_: () => { return; },
+      _method3: () => { return; }
     };
 
     const result = examine(obj);
 
     expect(result).to.be.an.object();
     expect(result.methods).to.have.length(3);
-    expect(result.methods).to.contain(["method1", "method2", "method3"]);
+    expect(result.methods).to.contain(["method1", "method2_", "_method3"]);
+
+    return done();
+
+  });
+
+  lab.test("can detect a private method on the instance of the object", done => {
+
+    const obj = {
+      method1_: () => { return; },
+      _method2: () => { return; }
+    };
+
+    const result = examine(obj);
+
+    expect(result).to.be.an.object();
+    expect(result.privateMethods).to.have.length(2);
+    expect(result.privateMethods).to.contain(["method1_", "_method2"]);
+
+    return done();
+
+  });
+
+  lab.test("can detect a public method on the instance of the object", done => {
+
+    const obj = {
+      method1: () => { return; },
+      method2: () => { return; }
+    };
+
+    const result = examine(obj);
+
+    expect(result).to.be.an.object();
+    expect(result.publicMethods).to.have.length(2);
+    expect(result.publicMethods).to.contain(["method1", "method2"]);
 
     return done();
 


### PR DESCRIPTION
Change returned object to differentiate between public and private methods

Backwards compatible, this should be a minor version change. 

I'll even update cooperate for you as well if I get time