### PR TITLE
[detect public and private methods from a prototype]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 [Tt]humbs.db
 *.DS_Store
 
+.idea
+
 #Visual Studio files
 *.[Oo]bj
 *.user

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -88,6 +88,14 @@ export default function examine(target) {
     if (descriptor.value !== undefined && typeof descriptor.value === "function") {
 
       examination.methods.push(value);
+
+      const isPrivateMethod = privateNameExp.exec(value);
+
+      if (isPrivateMethod) {
+        examination.privateMethods.push(value);
+      } else {
+        examination.publicMethods.push(value);
+      }
       continue;
     }
 

--- a/src/test/index-test.js
+++ b/src/test/index-test.js
@@ -170,6 +170,34 @@ group("The examine() function", () => {
 
   });
 
+  lab.test("can detect a private method on the instance of the class", done => {
+
+    const obj = new MyClass();
+
+    const result = examine(obj);
+
+    expect(result).to.be.an.object();
+    expect(result.privateMethods).to.have.length(1);
+    expect(result.privateMethods).to.contain(["method2_"]);
+
+    return done();
+
+  });
+
+  lab.test("can detect a public method on the instance of the class", done => {
+
+    const obj = new MyClass();
+
+    const result = examine(obj);
+
+    expect(result).to.be.an.object();
+    expect(result.publicMethods).to.have.length(1);
+    expect(result.publicMethods).to.contain(["method1"]);
+
+    return done();
+
+  });
+
   lab.test("can detect a raw attribute on the prototype of the object", done => {
 
     const Class = (function () {


### PR DESCRIPTION
The current version of examine-instance does not identifies the public and private methods if they are part of the prototype. The PR is to enable this feature.